### PR TITLE
Update golang to v1.20.7

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -5,11 +5,11 @@ FROM $FROM
 # Install golang
 RUN cd /root \
     && curl --proto '=https' --tlsv1.2 -sSf \
-        https://dl.google.com/go/go1.17.1.linux-amd64.tar.gz \
-        -o go1.17.1.linux-amd64.tar.gz \
-    && tar -C /usr/local -xzf go1.17.1.linux-amd64.tar.gz \
+        https://dl.google.com/go/go1.20.7.linux-amd64.tar.gz \
+        -o go1.20.7.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go1.20.7.linux-amd64.tar.gz \
     && mkdir go \
-    && rm go1.17.1.linux-amd64.tar.gz
+    && rm go1.20.7.linux-amd64.tar.gz
 
 # Add go binaries to PATH
 ENV PATH="$PATH:/usr/local/go/bin"


### PR DESCRIPTION
go only supports the two most recent minor versions: 1.20 and 1.21; 1.21 just released (1.20.0) so 1.20 will be supported for 6 more months, until 1.22 releases.

Go has had no breaking changes since the previous release used, 1.17 however it has added a new syntax for generics in 1.18.

Go does very well keeping code written in older versions working: https://tip.golang.org/doc/go1compat